### PR TITLE
New configFile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can pass options to the RelayCompilerPlugin which corespond to relay-compile
 
 ```ts
 export interface RelayCompilerPluginOptions {
+  configFile?: string;
   watch?: boolean;
   validate?: boolean;
   output?: OutputKind;

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -18,7 +18,7 @@ export class RelayCompiler implements IRelayCompiler {
   private subprocess?: ChildProcess;
   private errorMessage: string = '';
 
-  constructor(private args: string[]) { }
+  constructor(private args: string[], private configFile?: string) {}
 
   get hasError() { 
     return this.errorMessage.length > 0;
@@ -30,7 +30,8 @@ export class RelayCompiler implements IRelayCompiler {
 
   runOnce() {
     this.errorMessage = '';
-    const subprocess = spawn.sync(RELAY, this.args);
+    const args = this.configFile ? [...this.args, this.configFile] : this.args;
+    const subprocess = spawn.sync(RELAY, args);
     if (subprocess.stdout?.byteLength > 0) {
       console.log(`${subprocess.stdout}`);
     }
@@ -44,8 +45,9 @@ export class RelayCompiler implements IRelayCompiler {
   watch(callback?: () => void) {
     if (!this.subprocess) {
       // Start relay-compiler in watch mode
-      this.subprocess = spawn(RELAY, [...this.args, '--watch']);
-      this.subprocess?.stderr?.setEncoding('utf-8');
+      const subArgs = this.configFile ? [...this.args, "--watch", this.configFile] : [...this.args, "--watch"];
+      this.subprocess = spawn(RELAY, subArgs);
+      this.subprocess?.stderr?.setEncoding("utf-8");
       // Clear errors during compilation
       this.subprocess?.stdout?.on('data', chunk => {
         if (String(chunk).toLowerCase().includes(COMPILING)) {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -16,6 +16,7 @@ export enum OutputKind {
 }
 
 export interface RelayCompilerPluginOptions {
+  configFile?: string;
   watch?: boolean;
   validate?: boolean;
   output?: OutputKind;
@@ -31,11 +32,17 @@ export class RelayCompilerPlugin implements WebpackPluginInstance {
   private options: RelayCompilerPluginOptions;
   private relayCompiler: IRelayCompiler;
 
-  constructor(options: RelayCompilerPluginOptions) {
+  constructor(
+    options: RelayCompilerPluginOptions,
+    private configFile?: string
+  ) {
     const merged = { ...RelayCompilerPlugin.defaultOptions, ...options };
     validate(schema, merged, { name: PLUGIN_NAME });
     this.options = merged;
-    this.relayCompiler = new RelayCompiler(getRelayArgs(this.options));
+    this.relayCompiler = new RelayCompiler(
+      getRelayArgs(this.options),
+      this.configFile
+    );
   }
 
   apply(compiler: Compiler) {


### PR DESCRIPTION
The relay-compiler has the following signature:

```
USAGE:
    relay [OPTIONS] [CONFIG]

ARGS:
    <CONFIG>    Compile using this config file. If not provided, searches for a config in package.json under the `relay` key or `relay.config.json` files among other up from the current working directory

OPTIONS:
   ...
```

This change allows configuration through named config files (`<CONFIG>` arg).
The need was triggered by a current bug in Relay around auto-detection of config files with their default naming: https://github.com/facebook/relay/issues/3890

The arg is passed to Relay compiler without any additional path resolution or sanitisation,
which feels inline with providing a lightweight Webpack wrapper around the relay-compiler CLI command.
