### PR TITLE
Refactor config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can pass options to the RelayCompilerPlugin which corespond to relay-compile
 
 ```ts
 export interface RelayCompilerPluginOptions {
-  configFile?: string;
+  config?: string;
   watch?: boolean;
   validate?: boolean;
   output?: OutputKind;
@@ -43,9 +43,11 @@ export interface RelayCompilerPluginOptions {
 
 Default option is `watch: true`. If `watchman` isn't installed, then option `watch: false` is being applied.
 
+Option `config` defines path to a config file. If not provided, searches for a config in package.json under the `relay` key or `relay.config.json` files among other up from the current working directory.
+
 Changing `validate` option is not recommended, because the plugin reads output in the watch mode.
 
-## How it works
+## How does it work
 
 Depending on options, relay-compiler can be run in the watch mode or after every file change detected by webpack.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ch1ffa/relay-compiler-webpack-plugin",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "Webpack pluging for running relay-compiler in webpack dev mode",
   "author": {
     "name": "Vadim Evseev",

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -18,7 +18,7 @@ export class RelayCompiler implements IRelayCompiler {
   private subprocess?: ChildProcess;
   private errorMessage: string = '';
 
-  constructor(private args: string[], private configFile?: string) {}
+  constructor(private args: string[]) {}
 
   get hasError() { 
     return this.errorMessage.length > 0;
@@ -30,8 +30,7 @@ export class RelayCompiler implements IRelayCompiler {
 
   runOnce() {
     this.errorMessage = '';
-    const args = this.configFile ? [...this.args, this.configFile] : this.args;
-    const subprocess = spawn.sync(RELAY, args);
+    const subprocess = spawn.sync(RELAY, this.args);
     if (subprocess.stdout?.byteLength > 0) {
       console.log(`${subprocess.stdout}`);
     }
@@ -45,8 +44,7 @@ export class RelayCompiler implements IRelayCompiler {
   watch(callback?: () => void) {
     if (!this.subprocess) {
       // Start relay-compiler in watch mode
-      const subArgs = this.configFile ? [...this.args, "--watch", this.configFile] : [...this.args, "--watch"];
-      this.subprocess = spawn(RELAY, subArgs);
+      this.subprocess = spawn(RELAY, [...this.args, '--watch']);
       this.subprocess?.stderr?.setEncoding("utf-8");
       // Clear errors during compilation
       this.subprocess?.stdout?.on('data', chunk => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,7 +6,7 @@ import { schema } from './schema';
 import { IRelayCompiler, RelayCompiler } from './compiler';
 import { checkWatchman, getRelayArgs } from './utils';
 
-const PLUGIN_NAME = "relay-compiler-webpack-plugin";
+const PLUGIN_NAME = 'relay-compiler-webpack-plugin';
 
 export enum OutputKind {
   DEBUG = 'debug',
@@ -16,7 +16,7 @@ export enum OutputKind {
 }
 
 export interface RelayCompilerPluginOptions {
-  configFile?: string;
+  config?: string;
   watch?: boolean;
   validate?: boolean;
   output?: OutputKind;
@@ -32,17 +32,11 @@ export class RelayCompilerPlugin implements WebpackPluginInstance {
   private options: RelayCompilerPluginOptions;
   private relayCompiler: IRelayCompiler;
 
-  constructor(
-    options: RelayCompilerPluginOptions,
-    private configFile?: string
-  ) {
+  constructor(options: RelayCompilerPluginOptions) {
     const merged = { ...RelayCompilerPlugin.defaultOptions, ...options };
     validate(schema, merged, { name: PLUGIN_NAME });
     this.options = merged;
-    this.relayCompiler = new RelayCompiler(
-      getRelayArgs(this.options),
-      this.configFile
-    );
+    this.relayCompiler = new RelayCompiler(getRelayArgs(this.options));
   }
 
   apply(compiler: Compiler) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -3,9 +3,11 @@ import { Schema } from "schema-utils/declarations/validate";
 export const schema: Schema = {
   type: 'object',
   properties: {
+    config: {
+      type: 'string',
+    },
     watch: {
       type: 'boolean',
-
     },
     validate: {
       type: 'boolean',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import spawn from "cross-spawn";
-import { RelayCompilerPluginOptions } from "./plugin";
+import spawn from 'cross-spawn';
+import { RelayCompilerPluginOptions } from './plugin';
 
 const WATCHMAN = 'watchman';
 
@@ -15,8 +15,8 @@ export const checkWatchman = () => {
 }
 
 export const getRelayArgs = (options: RelayCompilerPluginOptions): string[] => {
-  // Ignore --watch option. Will be added later if need be
-  const { watch, ...args } = options;
+  // Ignore --watch and config options. Will be added later if need be
+  const { config, watch, ...args } = options;
   let result: string[] = []
   Object.entries(args).forEach(([key, value]) => {
     result.push(`--${key}`);
@@ -24,5 +24,5 @@ export const getRelayArgs = (options: RelayCompilerPluginOptions): string[] => {
       result.push(`${value}`);
     }
   })
-  return result;
+  return config ? [...result, config] : result;
 }


### PR DESCRIPTION
Changed option name `configFile` to `config` like in relay-compiler.

Moved `config` option to options for validation according to the schema.

Publish as version 0.2.0