### PR TITLE
Update to Relay 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module.exports = {
 
 ## Options
 
-You can pass options to the RelayCompilerPlugin which corespond to relay-compiler CLI options:
+You can pass options to the RelayCompilerPlugin which correspond to relay-compiler CLI options:
 
 ```ts
 export interface RelayCompilerPluginOptions {
@@ -35,9 +35,6 @@ export interface RelayCompilerPluginOptions {
   validate?: boolean;
   output?: OutputKind;
   repersist?: boolean;
-  artifactDirectory?: string;
-  schema?: string;
-  src?: string;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "schema-utils": "^4.0.0"
   },
   "peerDependencies": {
-    "relay-compiler": "^13.0.2"
+    "relay-compiler": "^14.0.0"
   }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,9 +21,6 @@ export interface RelayCompilerPluginOptions {
   validate?: boolean;
   output?: OutputKind;
   repersist?: boolean;
-  artifactDirectory?: string;
-  schema?: string;
-  src?: string;
 }
 
 export class RelayCompilerPlugin implements WebpackPluginInstance {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -18,15 +18,6 @@ export const schema: Schema = {
     repersist: {
       type: 'boolean'
     },
-    artifactDirectory: {
-      type: 'string'
-    },
-    schema: {
-      type: 'string'
-    },
-    src: {
-      type: 'string'
-    },
   },
   'additionalProperties': false,
 };


### PR DESCRIPTION
Thanks for making this plugin! I took a stab at upgrading this to Relay 14, which released recently.

They removed the `--src`, `--schema`, and `--artifactDirectory` CLI args in v14, so that they're only configurable from the config file now. I removed those options here to match. I don't see anything else in [the patch notes](https://github.com/facebook/relay/releases/tag/v14.0.0) that seems like it would cause issues for this plugin.

I tested this locally, with no config options, and confirmed that it's working for me.